### PR TITLE
Fix building on 32-bit platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
-          targets: x86_64-unknown-none
+          targets: x86_64-unknown-none,thumbv8m.main-none-eabihf
           components: clippy
 
       - name: install cargo-hack
@@ -113,6 +113,9 @@ jobs:
 
       - name: cargo clippy (no_std)
         run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target x86_64-unknown-none -- -D warnings
+
+      - name: cargo clippy (no_std 32-bit)
+        run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target thumbv8m.main-none-eabihf -- -D warnings
 
       - name: cargo clippy
         run: cargo hack clippy --workspace --locked --optional-deps --each-feature --ignore-unknown-features --features std -- -D warnings
@@ -213,7 +216,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_MIN_VER }}
-          targets: x86_64-unknown-none
+          targets: x86_64-unknown-none,thumbv8m.main-none-eabihf
 
       - name: install cargo-hack
         uses: taiki-e/install-action@v2
@@ -227,6 +230,9 @@ jobs:
 
       - name: cargo check (no_std)
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target x86_64-unknown-none
+
+      - name: cargo check (no_std 32-bit)
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features libm --exclude-features ${{ env.FEATURES_DEPENDING_ON_STD }} --target thumbv8m.main-none-eabihf
 
       - name: cargo check
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features std


### PR DESCRIPTION
Fixes compilation of `linebender_resource_handle` on 32-bit platforms that don't define `std::sync::AtomicU64`.
Needed for `cosmic-text` https://github.com/pop-os/cosmic-text/pull/424 (and just generally a good idea)