### PR TITLE
Add support for the `StableDeref` trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.92" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.88" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.88" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.92" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ You can find its changes [documented below](#011-2025-09-16).
 
 This release has an [MSRV][] of 1.70.
 
+### Added
+- If the `stable_deref_trait_v1` feature is enabled, `Blob<T>` now implements `StableDeref` from the `stable_deref_trait` crate. This allows it to be used with crates like `yoke`, enabling zero-copy deserialization of data backed by a `Blob<T>`.([#14][] by [@valadaptive][])
+
+### Changed
+
+- Breaking change: `Blob` can no longer be backed by any type that implements `AsRef<[T]> + Send + Sync`, instead requiring all backing storage types to have a stable address. This is guaranteed via a new `BlobStorage<T>` marker trait, which is implemented here for `Vec<T>`, `Box<[T]>`, and `Arc<[T]>`. ([#14][] by [@valadaptive][])
+
 ## [0.1.1][] (2025-09-16)
 
 This release has an [MSRV][] of 1.70.
@@ -37,6 +44,7 @@ This is the initial release.
 
 [#5]: https://github.com/linebender/raw_resource_handle/pull/5
 [#11]: https://github.com/linebender/raw_resource_handle/pull/11
+[#14]: https://github.com/linebender/raw_resource_handle/pull/14
 
 [Unreleased]: https://github.com/linebender/anymore/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/linebender/parley/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ You can find its changes [documented below](#011-2025-09-16).
 This release has an [MSRV][] of 1.70.
 
 ### Added
-- If the `stable_deref_trait_v1` feature is enabled, `Blob<T>` now implements `StableDeref` from the `stable_deref_trait` crate. This allows it to be used with crates like `yoke`, enabling zero-copy deserialization of data backed by a `Blob<T>`.([#14][] by [@valadaptive][])
+- If the `stable_deref_trait_v1` feature is enabled, `Blob<T>` now implements `StableDeref` from the `stable_deref_trait` crate. This allows it to be used with crates like `yoke`, enabling zero-copy deserialization of data backed by a `Blob<T>`. ([#14][] by [@valadaptive][])
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.1"
 dependencies = [
  "serde",
  "serde_bytes",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -56,6 +57,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,7 @@ serde = { version = "1.0.219", optional = true, default-features = false, featur
 serde_bytes = { version = "0.11.17", optional = true, default-features = false, features = [
     "alloc",
 ] }
-stable_deref_trait = { version = "1.2.1", optional = true, default-features = false, features = [
-    "alloc",
-] }
+stable_deref_trait = { version = "1.2.1", optional = true, default-features = false }
 
 [lints]
 rust.unsafe_code = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = ["std"]
 std = []
 # Adds serde Serialize and Deserialize impls for the Blob type.
 serde = ["dep:serde", "dep:serde_bytes"]
+# Implements the `StableDeref` trait for `Blob`, which can be used with crates like `yoke` to enable zero-copy
+# deserialization of data stored in the `Blob`.
+stable_deref_trait = ["dep:stable_deref_trait"]
 
 [dependencies]
 serde = { version = "1.0.219", optional = true, default-features = false, features = [
@@ -35,7 +38,9 @@ serde = { version = "1.0.219", optional = true, default-features = false, featur
 serde_bytes = { version = "0.11.17", optional = true, default-features = false, features = [
     "alloc",
 ] }
-stable_deref_trait = { version = "1.2.1", default-features = false, features = ["alloc"] }
+stable_deref_trait = { version = "1.2.1", optional = true, default-features = false, features = [
+    "alloc",
+] }
 
 [lints]
 # LINEBENDER LINT SET - Cargo.toml - v6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = ["std"]
 std = []
 # Adds serde Serialize and Deserialize impls for the Blob type.
 serde = ["dep:serde", "dep:serde_bytes"]
+# Implements the `StableDeref` trait for `Blob`, which can be used with crates like `yoke` to enable zero-copy
+# deserialization of data stored in the `Blob`.
+stable_deref_trait = ["dep:stable_deref_trait"]
 
 [dependencies]
 serde = { version = "1.0.219", optional = true, default-features = false, features = [
@@ -35,10 +38,9 @@ serde = { version = "1.0.219", optional = true, default-features = false, featur
 serde_bytes = { version = "0.11.17", optional = true, default-features = false, features = [
     "alloc",
 ] }
+stable_deref_trait = { version = "1.2.1", optional = true, default-features = false }
 
 [lints]
-rust.unsafe_code = "forbid"
-
 # LINEBENDER LINT SET - Cargo.toml - v6.1
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ default = ["std"]
 std = []
 # Adds serde Serialize and Deserialize impls for the Blob type.
 serde = ["dep:serde", "dep:serde_bytes"]
-# Implements the `StableDeref` trait for `Blob`, which can be used with crates like `yoke` to enable zero-copy
-# deserialization of data stored in the `Blob`.
-stable_deref_trait = ["dep:stable_deref_trait"]
 
 [dependencies]
 serde = { version = "1.0.219", optional = true, default-features = false, features = [
@@ -38,7 +35,7 @@ serde = { version = "1.0.219", optional = true, default-features = false, featur
 serde_bytes = { version = "0.11.17", optional = true, default-features = false, features = [
     "alloc",
 ] }
-stable_deref_trait = { version = "1.2.1", optional = true, default-features = false }
+stable_deref_trait = { version = "1.2.1", default-features = false, features = ["alloc"] }
 
 [lints]
 # LINEBENDER LINT SET - Cargo.toml - v6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ std = []
 serde = ["dep:serde", "dep:serde_bytes"]
 # Implements the `StableDeref` trait for `Blob`, which can be used with crates like `yoke` to enable zero-copy
 # deserialization of data stored in the `Blob`.
-stable_deref_trait = ["dep:stable_deref_trait"]
+stable_deref_trait_v1 = ["dep:stable_deref_trait"]
 
 [dependencies]
 serde = { version = "1.0.219", optional = true, default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ stable_deref_trait = { version = "1.2.1", optional = true, default-features = fa
 ] }
 
 [lints]
+rust.unsafe_code = "deny"
+
 # LINEBENDER LINT SET - Cargo.toml - v6.1
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use core::fmt;
+use core::ops::Deref;
 use core::sync::atomic::Ordering;
 extern crate alloc;
 use alloc::boxed::Box;
@@ -86,6 +87,17 @@ where
         Self::new(Arc::new(boxed))
     }
 }
+
+impl<T> Deref for Blob<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.data()
+    }
+}
+
+#[cfg(feature = "stable_deref_trait")]
+unsafe impl<T> stable_deref_trait::StableDeref for Blob<T> {}
 
 static ID_COUNTER: AtomicCounter = AtomicCounter::new(0);
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -19,7 +19,7 @@ use core::sync::atomic::AtomicU64 as AtomicCounter;
 ///
 /// # Safety
 ///
-/// Implementing this trait soundly requires that the `Deref` implementation returns the same address each time, as long
+/// Implementing this trait soundly requires that the `AsRef` implementation returns the same address each time, as long
 /// as the storage has not been mutated in-between (once placed in a [`Blob`], it's impossible to mutate the backing
 /// store, so the address must be stable thereafter).
 #[allow(unsafe_code)]

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -14,6 +14,10 @@ use core::sync::atomic::AtomicU32 as AtomicCounter;
 #[cfg(target_has_atomic = "64")]
 use core::sync::atomic::AtomicU64 as AtomicCounter;
 
+#[expect(
+    unsafe_code,
+    reason = "We are defining an unsafe trait, which is not in and of itself an unsafe thing to do"
+)]
 /// Marker trait for types that can be stored in a [`Blob`]. This is used to abstract over `Vec<T>`, `Box<[T]>`,
 /// `Arc<[T]>`, etc.
 ///
@@ -22,8 +26,20 @@ use core::sync::atomic::AtomicU64 as AtomicCounter;
 /// as the storage has not been mutated in-between (once placed in a [`Blob`], it's impossible to mutate the backing
 /// store, so the address must be stable thereafter).
 pub unsafe trait BlobStorage<T>: Deref<Target = [T]> + Send + Sync {}
+#[expect(
+    unsafe_code,
+    reason = "The contents of a Vec<T> have a stable address, as long as the Vec<T> is not mutated"
+)]
 unsafe impl<T: Send + Sync> BlobStorage<T> for Vec<T> {}
+#[expect(
+    unsafe_code,
+    reason = "The contents of a Box<[T]> have a stable address"
+)]
 unsafe impl<T: Send + Sync> BlobStorage<T> for Box<[T]> {}
+#[expect(
+    unsafe_code,
+    reason = "The contents of an Arc<[T]> have a stable address"
+)]
 unsafe impl<T: Send + Sync> BlobStorage<T> for Arc<[T]> {}
 
 /// Shared data with an associated unique identifier.
@@ -109,6 +125,10 @@ impl<T> Deref for Blob<T> {
 }
 
 #[cfg(feature = "stable_deref_trait")]
+#[expect(
+    unsafe_code,
+    reason = "The BlobStorage<T> trait guarantees a stable address as long as the backing store's contents are not mutated, and we put the backing store in an `Arc`, making it impossible to mutate"
+)]
 unsafe impl<T> stable_deref_trait::StableDeref for Blob<T> {}
 
 static ID_COUNTER: AtomicCounter = AtomicCounter::new(0);

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -21,13 +21,13 @@ use core::sync::atomic::AtomicU64 as AtomicCounter;
 /// Implementing this trait soundly requires that the `Deref` implementation returns the same address each time, as long
 /// as the storage has not been mutated in-between (once placed in a [`Blob`], it's impossible to mutate the backing
 /// store, so the address must be stable thereafter).
-#[expect(unsafe_code)]
+#[allow(unsafe_code)]
 pub unsafe trait BlobStorage<T>: Deref<Target = [T]> + Send + Sync {}
-#[expect(unsafe_code)] // The contents of a Vec<T> have a stable address, as long as the Vec<T> is not mutated
+#[allow(unsafe_code)] // The contents of a Vec<T> have a stable address, as long as the Vec<T> is not mutated
 unsafe impl<T: Send + Sync> BlobStorage<T> for Vec<T> {}
-#[expect(unsafe_code)] // The contents of a Box<[T]> have a stable address
+#[allow(unsafe_code)] // The contents of a Box<[T]> have a stable address
 unsafe impl<T: Send + Sync> BlobStorage<T> for Box<[T]> {}
-#[expect(unsafe_code)] // The contents of an Arc<[T]> have a stable address
+#[allow(unsafe_code)] // The contents of an Arc<[T]> have a stable address
 unsafe impl<T: Send + Sync> BlobStorage<T> for Arc<[T]> {}
 
 /// Shared data with an associated unique identifier.
@@ -117,7 +117,7 @@ impl<T> Deref for Blob<T> {
 //
 // The BlobStorage<T> trait guarantees a stable address as long as the backing store's contents are not mutated, and we
 // put the backing store in an `Arc`, making it impossible to mutate
-#[expect(unsafe_code)]
+#[allow(unsafe_code)]
 unsafe impl<T> stable_deref_trait::StableDeref for Blob<T> {}
 
 static ID_COUNTER: AtomicCounter = AtomicCounter::new(0);

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -14,10 +14,6 @@ use core::sync::atomic::AtomicU32 as AtomicCounter;
 #[cfg(target_has_atomic = "64")]
 use core::sync::atomic::AtomicU64 as AtomicCounter;
 
-#[expect(
-    unsafe_code,
-    reason = "We are defining an unsafe trait, which is not in and of itself an unsafe thing to do"
-)]
 /// Marker trait for types that can be stored in a [`Blob`]. This is used to abstract over `Vec<T>`, `Box<[T]>`,
 /// `Arc<[T]>`, etc.
 ///
@@ -25,21 +21,13 @@ use core::sync::atomic::AtomicU64 as AtomicCounter;
 /// Implementing this trait soundly requires that the `Deref` implementation returns the same address each time, as long
 /// as the storage has not been mutated in-between (once placed in a [`Blob`], it's impossible to mutate the backing
 /// store, so the address must be stable thereafter).
+#[expect(unsafe_code)]
 pub unsafe trait BlobStorage<T>: Deref<Target = [T]> + Send + Sync {}
-#[expect(
-    unsafe_code,
-    reason = "The contents of a Vec<T> have a stable address, as long as the Vec<T> is not mutated"
-)]
+#[expect(unsafe_code)] // The contents of a Vec<T> have a stable address, as long as the Vec<T> is not mutated
 unsafe impl<T: Send + Sync> BlobStorage<T> for Vec<T> {}
-#[expect(
-    unsafe_code,
-    reason = "The contents of a Box<[T]> have a stable address"
-)]
+#[expect(unsafe_code)] // The contents of a Box<[T]> have a stable address
 unsafe impl<T: Send + Sync> BlobStorage<T> for Box<[T]> {}
-#[expect(
-    unsafe_code,
-    reason = "The contents of an Arc<[T]> have a stable address"
-)]
+#[expect(unsafe_code)] // The contents of an Arc<[T]> have a stable address
 unsafe impl<T: Send + Sync> BlobStorage<T> for Arc<[T]> {}
 
 /// Shared data with an associated unique identifier.
@@ -125,10 +113,11 @@ impl<T> Deref for Blob<T> {
 }
 
 #[cfg(feature = "stable_deref_trait")]
-#[expect(
-    unsafe_code,
-    reason = "The BlobStorage<T> trait guarantees a stable address as long as the backing store's contents are not mutated, and we put the backing store in an `Arc`, making it impossible to mutate"
-)]
+// Safety:
+//
+// The BlobStorage<T> trait guarantees a stable address as long as the backing store's contents are not mutated, and we
+// put the backing store in an `Arc`, making it impossible to mutate
+#[expect(unsafe_code)]
 unsafe impl<T> stable_deref_trait::StableDeref for Blob<T> {}
 
 static ID_COUNTER: AtomicCounter = AtomicCounter::new(0);

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -17,6 +17,7 @@ use core::sync::atomic::AtomicU64 as AtomicCounter;
 /// Marker trait for types that can be stored in a [`Blob`]. This is used to abstract over `Vec<T>`, `Box<[T]>`,
 /// `Arc<[T]>`, etc.
 ///
+/// # Safety
 /// Implementing this trait soundly requires that the `Deref` implementation returns the same address each time, as long
 /// as the storage has not been mutated in-between (once placed in a [`Blob`], it's impossible to mutate the backing
 /// store, so the address must be stable thereafter).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ extern crate std as _;
 mod blob;
 mod font;
 
-pub use blob::{Blob, WeakBlob};
+pub use blob::{Blob, BlobStorage, WeakBlob};
 pub use font::FontData;
 
 #[cfg(test)]


### PR DESCRIPTION
As part of optimizing Parley, @taj-p noticed that we spend a surprising amount of time parsing out individual tables from each font.

Skrifa has a `FontRef<'a>` type, which references an `&'a [u8]`, and has getter methods for individual glyph collections (e.g. `OutlineGlyphCollection<'a>`, `ColorGlyphCollection<'a>`). Because of that lifetime parameter, it's not really possible to keep around those glyph collections. That's unfortunate, because it's a bit expensive to re-parse them each time we need them.

The [`yoke` crate](https://github.com/unicode-org/icu4x/tree/main/utils/yoke) provides a solution. It lets us construct "self-referential-ish" structures: if we have font data stored in a `Blob<u8>`, we can construct a `Yoke<FontRef<'static>, Blob<u8>>`. We know that the data referenced by the `FontRef` points into the `Blob<u8>`, so we can obtain a reference to the `FontRef<'static>` from the parent `Yoke`, which keeps both alive. This lets us pre-parse all the tables we want from a `FontData`, saving time.

This only works, however, if `Blob<u8>` implements the `StableDeref` trait, which is basically a guarantee that it'll always deref to the same address. If it could decide to just change its address, the `FontRef` would suddenly point to stale data, leading to unsoundness.

In order to avoid parsing the same font data over and over, we therefore need to implement `StableDeref` here. I've put it behind a feature, but the `stable_deref_trait` crate seems pretty lightweight and has no dependencies. Not sure if we should just depend on it unconditionally.

Since it's an unsafe marker trait, I just removed the "forbid unsafe code" lint entirely. This is a pretty small crate, and I think it's the right place for unsafe code to live. I *could* just add an `#[allow]` for that trait specifically, but I think the lint was left over from when this was part of peniko and not really worth it.