### PR TITLE
Expand soundness documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ This release has an [MSRV][] of 1.70.
 ### Added
 
 - If the `stable_deref_trait_v1` feature is enabled, `Blob<T>` now implements `StableDeref` from the `stable_deref_trait` crate. This allows it to be used with crates like `yoke`, enabling zero-copy deserialization of data backed by a `Blob<T>`. ([#14][] by [@valadaptive][])
+- `Blob` now guarantees validity of pointers derived from `Blob::data` for the duration of the `Blob`'s lifetime. ([#15][] by [@tomcur][])
 
 ### Changed
 
-- Breaking change: `Blob` can no longer be backed by any type that implements `AsRef<[T]> + Send + Sync`, instead requiring all backing storage types to have a stable address. This is guaranteed via a new `BlobStorage<T>` marker trait, which is implemented here for `Vec<T>`, `Box<[T]>`, and `Arc<[T]>`. ([#14][] by [@valadaptive][])
+- Breaking change: `Blob` can no longer be backed by any type that implements `AsRef<[T]> + Send + Sync`, instead requiring all backing storage types to have a stable address and for those pointers to remain valid. This is guaranteed via a new `BlobStorage<T>` marker trait, which is implemented here for `Vec<T>`, `Box<[T]>`, and `Arc<[T]>`. ([#14][] by [@valadaptive][])
 
 ## [0.1.1][] (2025-09-16)
 
@@ -41,12 +42,14 @@ This is the initial release.
 - Add the `Font`, `Blob`, and `WeakBlob` types. (Initial commits by [@waywardmonkeys][])
 
 [@nicoburns]: https://github.com/nicoburns
+[@tomcur]: https://github.com/tomcur
 [@valadaptive]: https://github.com/valadaptive
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
 [#5]: https://github.com/linebender/raw_resource_handle/pull/5
 [#11]: https://github.com/linebender/raw_resource_handle/pull/11
 [#14]: https://github.com/linebender/raw_resource_handle/pull/14
+[#15]: https://github.com/linebender/raw_resource_handle/pull/15
 
 [Unreleased]: https://github.com/linebender/anymore/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/linebender/parley/compare/v0.1.0...v0.1.1

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -177,8 +177,9 @@ impl<T> Blob<T> {
     /// # Guarantees for unsafe code
     ///
     /// For any given blob, this method will always return a reference pointing to the same memory.
-    /// That pointer remains valid for at least as long as this blob's lifetime (which in general
-    /// can be longer than the duration of the borrow).
+    /// Additionally, that pointer remains valid for at least as long as this blob's lifetime
+    /// (which in general can be longer than the duration of the borrow). This holds due to the
+    /// requirements on [`BlobStorage`].
     #[must_use]
     pub fn data(&self) -> &[T] {
         self.data.as_ref().as_ref()

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -179,7 +179,7 @@ impl<T> Blob<T> {
     /// For any given blob, this method will always return a reference pointing to the same memory.
     /// Additionally, that pointer remains valid for at least as long as this blob's lifetime
     /// (which in general can be longer than the duration of the borrow). This holds due to the
-    /// requirements on [`BlobStorage`].
+    /// requirements on the inner [`BlobStorage`].
     #[must_use]
     pub fn data(&self) -> &[T] {
         self.data.as_ref().as_ref()

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -19,9 +19,14 @@ use core::sync::atomic::AtomicU64 as AtomicCounter;
 ///
 /// # Safety
 ///
-/// Implementing this trait soundly requires that the `AsRef` implementation returns the same address each time, as long
-/// as the storage has not been mutated in-between (once placed in a [`Blob`], it's impossible to mutate the backing
-/// store, so the address must be stable thereafter).
+/// Implementing this trait soundly requires that, for as long as the backing storage is not
+/// mutated nor moved, each call to `AsRef`:
+/// - results in a reference pointing to the same memory; and
+/// - that the result remains valid for the entire duration, i.e., not just for the lifetime of the
+///   borrow but for at least until such time the storage is mutated or moved.
+///
+/// In the context of [`Blob`]s, once storage is placed in it, it's impossible to get exclusive
+/// access to or move the backing storage for the lifetime of the [`Blob`].
 #[allow(unsafe_code)]
 pub unsafe trait BlobStorage<T>: AsRef<[T]> + Send + Sync {}
 // The contents of a Vec<T> have a stable address, as long as the Vec<T> is not mutated.
@@ -168,6 +173,12 @@ impl<T> Blob<T> {
     }
 
     /// Returns a reference to the underlying data.
+    ///
+    /// # Guarantees for unsafe code
+    ///
+    /// For any given blob, this method will always return a reference pointing to the same memory.
+    /// That pointer remains valid for at least as long as this blob's lifetime (which in general
+    /// can be longer than the duration of the borrow).
     #[must_use]
     pub fn data(&self) -> &[T] {
         self.data.as_ref().as_ref()


### PR DESCRIPTION
See https://github.com/linebender/raw_resource_handle/pull/14#pullrequestreview-3673091574.

Copying the relevant part:

> I'm not completely convinced the documentation on requirements for `BlobStorage` implementation is sufficient for soundness. I think we need to say that the result of `as_ref` not only needs to be stable in terms of address, but that the pointer derived from it is valid for the lifetime of the object as well. We can say something to the effect that once `as_ref` is called (or once `as_ref` can be called), the object is guaranteed not to move due how `Blob` wraps it (which is the reason the implementation for `Box` is sound).
>
> I think we can then also make explicit the promises of `Blob::data`, namely that pointers derived from the reference returned remain valid for as long as the `Blob` lives, even if the `Blob` is moved.